### PR TITLE
Add dates to create competition

### DIFF
--- a/api/db/migrate/20230424150554_add_dates_to_competition.rb
+++ b/api/db/migrate/20230424150554_add_dates_to_competition.rb
@@ -1,0 +1,6 @@
+class AddDatesToCompetition < ActiveRecord::Migration[7.0]
+  def change
+    add_column :competitions, :start_date, :datetime
+    add_column :competitions, :end_date, :datetime
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema[7.0].define(version: 2023_04_13_142157) do
-
+ActiveRecord::Schema[7.0].define(version: 2023_04_24_150554) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,6 +40,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_142157) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "icon"
+    t.datetime "start_date"
+    t.datetime "end_date"
     t.index ["identifier"], name: "index_competitions_on_identifier", unique: true
   end
 

--- a/client/src/pages/newcompetition/CreateCompetition.jsx
+++ b/client/src/pages/newcompetition/CreateCompetition.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useDispatch } from "react-redux";
-import { participantsApiSlice, useGetParticipantsQuery } from "../../store/game/participantsApiSlice";
+import { useGetParticipantsQuery } from "../../store/game/participantsApiSlice";
 import { useCreateCompetitionMutation } from "../../store/game/competitionApiSlice";
 import GameRules from "./GameRules";
 import { setParticipantList } from "../../store/game/participantSlice";
@@ -14,6 +14,7 @@ function Create() {
     name: "", public: false, participants: [], icon: ""
   });
   const [selectedIcon, setSelectedIcon] = useState(null);
+  const [validationMessages, setValidationMessages] = useState("");
 
   const handleInput = (e) => {
     const getCompValue = (input) => {
@@ -55,19 +56,37 @@ function Create() {
 
       }}
     />);
-  })
+  });
+
+  const validateCompetitionData = () => {
+    if (!selectedIcon) {
+      throw new Error("You haven't selected a competition Icon!");
+    }
+    if (newCompData.participants.length <= 1) {
+      throw new Error("You need to select at least 2 participants!");
+    }
+    if (newCompData.name.length < 5) {
+      throw new Error("Competition Name must be at least 5 characters!");
+    }
+  };
 
   const handleCreateCompetition = async (e) => {
     e.preventDefault();
     try {
+      validateCompetitionData();
+    } catch (err) {
+      setValidationMessages(err.message);
+      console.error(err.message);
+      return;
+    }
+
+    try {
       const request = await createCompetition(newCompData).unwrap();
       console.log(request);
-
     } catch (err) {
       console.error(err.message);
     }
-
-  }
+  };
 
   const { data: participants, isError, isLoading } = useGetParticipantsQuery();
 
@@ -132,6 +151,7 @@ function Create() {
             value="Create Competition"
           />
         </form>
+        {validationMessages && <p style={{ color: "red" }}>{validationMessages}</p>}
 
         <h3>Game Rules</h3>
         <GameRules />

--- a/client/src/pages/newcompetition/CreateCompetition.jsx
+++ b/client/src/pages/newcompetition/CreateCompetition.jsx
@@ -11,15 +11,22 @@ function Create() {
   const dispatch = useDispatch();
   const [createCompetition] = useCreateCompetitionMutation();
   const [newCompData, setNewCompData] = useState({
-    name: "", public: false, participants: [], icon: ""
+    name: "", public: false, participants: [], icon: "", startDate: "", endDate: ""
   });
   const [selectedIcon, setSelectedIcon] = useState(null);
   const [validationMessages, setValidationMessages] = useState("");
+  const today = new Date();
+  const maxStartDate = new Date(Date.parse(today) + 3_600_000 * 24 * 30);
+  const maxEndDate = new Date((Date.parse(newCompData.startDate) || Date.parse(today)) + 3_600_000 * 24 * 365);
 
   const handleInput = (e) => {
     const getCompValue = (input) => {
       switch (input) {
         case "name":
+          return e.target.value;
+        case "startDate":
+          return e.target.value;
+        case "endDate":
           return e.target.value;
         case "public":
           return e.target.checked;
@@ -141,7 +148,25 @@ function Create() {
             />
           </div>
 
+          <label htmlFor="startDate">Start Date:</label>
+          <input
+            type="date"
+            name="startDate"
+            onChange={handleInput}
+            min={today.toISOString().substring(0, 10)}
+            max={maxStartDate.toISOString().substring(0, 10)}
+            value={newCompData.startDate}
+          />
+          <label htmlFor="endDate">End Date:</label>
+          <input
+            type="date"
+            name="endDate"
+            min={newCompData.startDate}
+            max={maxEndDate?.toISOString().substring(0, 10)}
 
+            onChange={handleInput}
+            value={newCompData.endDate}
+          />
           <div className="select-participants">
             <label>Select Participants:</label>
             {mapParticipants}


### PR DESCRIPTION
1. Added start_date and end_date to Competition model (run migrations on next pull);
2. Start_date validations - from today to up to one month from now;
3. End_date validations - from the start date until up to one year from now; This addresses Issue #55 
4. Added Create Competition Validations - user must select a competition icon, enter a competition name of at least 5 characters and select at least two participants, otherwise will render an error message and will not proceed with the POST request. This addresses Issue #63 