### PR TITLE
Fix auth redirect on jwt expiry

### DIFF
--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -18,7 +18,8 @@ class ApplicationController < ActionController::API
             decoded = jwt_decode(header)
             @current_user = User.find(decoded[:user_id])
             blacklisted_token = BlacklistedToken.find_by(token: header, user_id: decoded[:user_id])
-            if blacklisted_token && blacklisted_token.expires_at >= Time.current
+            if blacklisted_token 
+                # puts "line 22", (blacklisted_token.expires_at < Time.current)
                 render json: { error: "Token has been blacklisted" }, status: :unauthorized
             end
         rescue JWT::DecodeError, ActiveRecord::RecordNotFound

--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -13,6 +13,8 @@ class ApplicationController < ActionController::API
         if header[0...6] == "token="
             header = header[6...]
         end
+
+        puts "on line 17 in app_controller:", header
         
         begin
             decoded = jwt_decode(header)

--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -13,15 +13,12 @@ class ApplicationController < ActionController::API
         if header[0...6] == "token="
             header = header[6...]
         end
-
-        puts "on line 17 in app_controller:", header
         
         begin
             decoded = jwt_decode(header)
             @current_user = User.find(decoded[:user_id])
             blacklisted_token = BlacklistedToken.find_by(token: header, user_id: decoded[:user_id])
             if blacklisted_token 
-                # puts "line 22", (blacklisted_token.expires_at < Time.current)
                 render json: { error: "Token has been blacklisted" }, status: :unauthorized
             end
         rescue JWT::DecodeError, ActiveRecord::RecordNotFound

--- a/api/app/controllers/competitions_controller.rb
+++ b/api/app/controllers/competitions_controller.rb
@@ -1,4 +1,5 @@
 class CompetitionsController < ApplicationController
+    before_action :authenticate_request
 
     def leaderboard
         competition = Competition.find(params[:id])

--- a/api/app/models/blacklisted_token.rb
+++ b/api/app/models/blacklisted_token.rb
@@ -2,6 +2,9 @@ class BlacklistedToken < ApplicationRecord
     belongs_to :user
 
     def self.delete_expired_tokens
-        self.where("expires_at < ?", Time.current).delete_all
+        puts "running deleted_expired_tokens"
+        # self.where("expires_at < ?", Time.current).delete_all
+        self.first.destroy
+        
     end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   post "/auth/login", to: "authentication#login"
   post "/auth/signup", to: "authentication#signup"
   patch "/auth/update_profile", to: "users#update"
+  post "/auth/autologin", to: "authentication#autologin"
   delete "/logout", to: "authentication#logout"
   post "/competition/join", to: "competitions#join"
   get "/competition/leaderboard/:id", to: "competitions#leaderboard"

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   post "/auth/signup", to: "authentication#signup"
   patch "/auth/update_profile", to: "users#update"
   post "/auth/autologin", to: "authentication#autologin"
+  get "/auth/refresh", to: "authentication#refresh"
   delete "/logout", to: "authentication#logout"
   post "/competition/join", to: "competitions#join"
   get "/competition/leaderboard/:id", to: "competitions#leaderboard"

--- a/api/config/schedule.rb
+++ b/api/config/schedule.rb
@@ -1,4 +1,8 @@
-every 1.day, at: "4:30 am" do
+# every 1.day, at: "4:30 am" do
+#     rake "tokens:cleanup_expired_tokens"
+#   end
+
+every 1.minute do
     rake "tokens:cleanup_expired_tokens"
-  end
+end
   

--- a/api/lib/json_web_token.rb
+++ b/api/lib/json_web_token.rb
@@ -2,7 +2,7 @@ module JsonWebToken
     extend ActiveSupport::Concern
     SECRET_KEY = Rails.application.secret_key_base
     
-    def jwt_encode(payload, exp = 1.minute.from_now)
+    def jwt_encode(payload, exp = 3.days.from_now)
         raise ArgumentError, "Payload must be a hash" unless payload.is_a?(Hash)
         raise ArgumentError, "Expiration time must be a valid time object" unless exp.respond_to?(:to_i)
         payload[:exp] = exp.to_i

--- a/api/lib/json_web_token.rb
+++ b/api/lib/json_web_token.rb
@@ -4,7 +4,14 @@ module JsonWebToken
     
     def jwt_encode(payload, exp = 3.days.from_now)
         raise ArgumentError, "Payload must be a hash" unless payload.is_a?(Hash)
-    raise ArgumentError, "Expiration time must be a valid time object" unless exp.respond_to?(:to_i)
+        raise ArgumentError, "Expiration time must be a valid time object" unless exp.respond_to?(:to_i)
+        payload[:exp] = exp.to_i
+        JWT.encode(payload, SECRET_KEY)
+    end
+
+    def jwt_refresh(payload, exp = 30.days.from_now)
+        raise ArgumentError, "Payload must be a hash" unless payload.is_a?(Hash)
+        raise ArgumentError, "Expiration time must be a valid time object" unless exp.respond_to?(:to_i)
         payload[:exp] = exp.to_i
         JWT.encode(payload, SECRET_KEY)
     end

--- a/api/lib/json_web_token.rb
+++ b/api/lib/json_web_token.rb
@@ -2,7 +2,7 @@ module JsonWebToken
     extend ActiveSupport::Concern
     SECRET_KEY = Rails.application.secret_key_base
     
-    def jwt_encode(payload, exp = 3.days.from_now)
+    def jwt_encode(payload, exp = 1.minute.from_now)
         raise ArgumentError, "Payload must be a hash" unless payload.is_a?(Hash)
         raise ArgumentError, "Expiration time must be a valid time object" unless exp.respond_to?(:to_i)
         payload[:exp] = exp.to_i

--- a/api/lib/tasks/blacklisted_tokens.rake
+++ b/api/lib/tasks/blacklisted_tokens.rake
@@ -1,6 +1,7 @@
 namespace :tokens do
     desc 'Clean up expired BlacklistedTokens'
     task cleanup_expired_tokens: :environment do
+      puts "in line 4 of blacklisted_token.rake"
       BlacklistedToken.delete_expired_tokens
     end
   end

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3936,7 +3936,8 @@
     "@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
-      "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A=="
+      "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
+      "requires": {}
     },
     "@emotion/utils": {
       "version": "1.2.0",
@@ -3958,7 +3959,8 @@
     "@hookform/resolvers": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.0.0.tgz",
-      "integrity": "sha512-SQPefakODpyq25b/phHXDKCdRrEfPcCXV7B4nAa139wE1DxufYbbNAjeo0T04ZXBokRxZ+wD8iA1kkVMa3QwjQ=="
+      "integrity": "sha512-SQPefakODpyq25b/phHXDKCdRrEfPcCXV7B4nAa139wE1DxufYbbNAjeo0T04ZXBokRxZ+wD8iA1kkVMa3QwjQ==",
+      "requires": {}
     },
     "@jest/expect-utils": {
       "version": "29.5.0",
@@ -4113,7 +4115,8 @@
     "@mui/types": {
       "version": "7.2.4",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.4.tgz",
-      "integrity": "sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA=="
+      "integrity": "sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA==",
+      "requires": {}
     },
     "@mui/utils": {
       "version": "5.12.0",
@@ -4170,49 +4173,57 @@
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.5.1.tgz",
       "integrity": "sha512-9PYGcXrAxitycIjRmZB+Q0JaN07GZIWaTBIGQzfaZv+qr1n8X1XUEJ5rZ/vx6OVD9RRYlrNnXWExQXcmZeD/BQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-remove-jsx-attribute": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-6.5.0.tgz",
       "integrity": "sha512-8zYdkym7qNyfXpWvu4yq46k41pyNM9SOstoWhKlm+IfdCE1DdnRKeMUPsWIEO/DEkaWxJ8T9esNdG3QwQ93jBA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-remove-jsx-empty-expression": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-6.5.0.tgz",
       "integrity": "sha512-NFdxMq3xA42Kb1UbzCVxplUc0iqSyM9X8kopImvFnB+uSDdzIHOdbs1op8ofAvVRtbg4oZiyRl3fTYeKcOe9Iw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-replace-jsx-attribute-value": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-6.5.1.tgz",
       "integrity": "sha512-8DPaVVE3fd5JKuIC29dqyMB54sA6mfgki2H2+swh+zNJoynC8pMPzOkidqHOSc6Wj032fhl8Z0TVn1GiPpAiJg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-svg-dynamic-title": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-6.5.1.tgz",
       "integrity": "sha512-FwOEi0Il72iAzlkaHrlemVurgSQRDFbk0OC8dSvD5fSBPHltNh7JtLsxmZUhjYBZo2PpcU/RJvvi6Q0l7O7ogw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-svg-em-dimensions": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-6.5.1.tgz",
       "integrity": "sha512-gWGsiwjb4tw+ITOJ86ndY/DZZ6cuXMNE/SjcDRg+HLuCmwpcjOktwRF9WgAiycTqJD/QXqL2f8IzE2Rzh7aVXA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-transform-react-native-svg": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-6.5.1.tgz",
       "integrity": "sha512-2jT3nTayyYP7kI6aGutkyfJ7UMGtuguD72OjeGLwVNyfPRBD8zQthlvL+fAbAKk5n9ZNcvFkp/b1lZ7VsYqVJg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-transform-svg-component": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-6.5.1.tgz",
       "integrity": "sha512-a1p6LF5Jt33O3rZoVRBqdxL350oge54iZWHNI6LJB5tQ7EelvD/Mb1mfBiZNAan0dt4i3VArkFRjA4iObuNykQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-preset": {
       "version": "6.5.1",
@@ -5565,7 +5576,8 @@
     "react-hook-form": {
       "version": "7.43.7",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.7.tgz",
-      "integrity": "sha512-38yehQkQQ5uufaPKFScs7jhLE8n3+LG9H/BZfFAiBL2+7piDmw/BrdNJV4irzMaPnWZGhmGLHVICHXNVGIuXZg=="
+      "integrity": "sha512-38yehQkQQ5uufaPKFScs7jhLE8n3+LG9H/BZfFAiBL2+7piDmw/BrdNJV4irzMaPnWZGhmGLHVICHXNVGIuXZg==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",
@@ -5646,7 +5658,8 @@
     "redux-thunk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
-      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q=="
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "requires": {}
     },
     "regenerator-runtime": {
       "version": "0.13.11",
@@ -5814,7 +5827,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-2.1.1.tgz",
       "integrity": "sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "universal-cookie": {
       "version": "4.0.4",
@@ -5845,7 +5859,8 @@
     "use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "uuid": {
       "version": "9.0.0",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import TournamentPage from "./pages/tournaments/TournamentPage";
 import FriendsPage from "./pages/friend/FriendsPage";
 import "./App.css";
 import Notifications from "./pages/notifications/Notifications";
+import PageNotFound from "./components/PageNotFound";
 
 function App() {
   return (
@@ -18,6 +19,7 @@ function App() {
           {/* public routes */}
           <Route index element={<Main />} />
           <Route path="auth" element={<Authorization />} />
+          <Route path="*" element={<PageNotFound />} />
 
           {/* protected routes */}
           <Route element={<RequireAuth />}>

--- a/client/src/app/api/apiSlice.js
+++ b/client/src/app/api/apiSlice.js
@@ -23,10 +23,10 @@ const baseQuery = fetchBaseQuery({
 const baseQueryWithReauth = async (args, api, extraOptions) => {
   let result = await baseQuery(args, api, extraOptions);
 
-  if (result?.error?.originalStatus === 403) {
+  if (result?.error?.originalStatus === 401) {
     console.log("sending refresh token");
     // send refresh token to get new access token
-    const refreshResult = await baseQuery("/refresh", api, extraOptions);
+    const refreshResult = await baseQuery("/auth/refresh", api, extraOptions);
     console.log(refreshResult);
     if (refreshResult?.data) {
       const user = api.getState().auth.user;
@@ -35,6 +35,7 @@ const baseQueryWithReauth = async (args, api, extraOptions) => {
       // retry the original query with new access token
       result = await baseQuery(args, api, extraOptions);
     } else {
+      // need to fix the below
       api.dispatch(logOut());
     }
   }

--- a/client/src/app/api/apiSlice.js
+++ b/client/src/app/api/apiSlice.js
@@ -22,8 +22,8 @@ const baseQuery = fetchBaseQuery({
 
 const baseQueryWithReauth = async (args, api, extraOptions) => {
   let result = await baseQuery(args, api, extraOptions);
-
-  if (result?.error?.originalStatus === 401) {
+  console.log(result?.error?.status)
+  if (result?.error?.status === 401) {
     console.log("sending refresh token");
     // send refresh token to get new access token
     const refreshResult = await baseQuery("/auth/refresh", api, extraOptions);

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -33,6 +33,7 @@ function Header() {
       await logout({ headers: { Authorization: `Bearer  ${token}` } });
       dispatch(logOut());
       removeCookie("token");
+      removeCookie("refresh");
       localStorage.clear();
       navigate("/");
     } catch (error) {

--- a/client/src/components/PageNotFound.jsx
+++ b/client/src/components/PageNotFound.jsx
@@ -1,0 +1,9 @@
+const PageNotFound = () => {
+    return (
+        <div>
+            <h1>404 Page Not Found</h1>
+        </div>
+    );
+};
+
+export default PageNotFound;

--- a/client/src/pages/account/Profile.jsx
+++ b/client/src/pages/account/Profile.jsx
@@ -14,7 +14,7 @@ function Profile() {
   const user = useSelector(selectCurrentUser);
   const dispatch = useDispatch();
   const { data: competitions, isLoading: isCompsLoading, refetch: refetchComps } = useGetCompetitionsQuery(user.id);
-  const { data: friends, isLoading } = useGetFriendsQuery();
+  const { data: friends } = useGetFriendsQuery();
 
   useEffect(() => {
     refetchComps();

--- a/client/src/pages/account/Profile.jsx
+++ b/client/src/pages/account/Profile.jsx
@@ -9,9 +9,7 @@ import MainFeed from "./MainFeed";
 import EditProfileModal from "./EditProfileModal";
 import CompetitionCard from "./CompetitionCard";
 import "./Profile.css";
-import { apiSlice } from "../../app/api/apiSlice";
 
-console.log(apiSlice)
 
 function Profile() {
   const user = useSelector(selectCurrentUser);

--- a/client/src/pages/account/Profile.jsx
+++ b/client/src/pages/account/Profile.jsx
@@ -9,6 +9,9 @@ import MainFeed from "./MainFeed";
 import EditProfileModal from "./EditProfileModal";
 import CompetitionCard from "./CompetitionCard";
 import "./Profile.css";
+import { apiSlice } from "../../app/api/apiSlice";
+
+console.log(apiSlice)
 
 function Profile() {
   const user = useSelector(selectCurrentUser);
@@ -24,7 +27,6 @@ function Profile() {
     if (isCompsLoading) {
       return;
     } else {
-      console.log()
       dispatch(setCompetitions([...competitions]));
     }
   }, [competitions])

--- a/client/src/pages/auth/Authorization.jsx
+++ b/client/src/pages/auth/Authorization.jsx
@@ -6,9 +6,6 @@ import { useNavigate } from "react-router-dom";
 import { useCookies } from "react-cookie";
 import { useAutoLoginMutation } from "../../store/auth/authApiSlice";
 
-const tempJWT = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjo0LCJleHAiOjE2ODc2Mjk4MDh9.XlwiPmLb5Euc21zvdBSotP-HTp83-wf1HNmV_l60_uU"
-
-
 function Authorization() {
   const navigate = useNavigate();
   const user = useSelector(selectCurrentUser);
@@ -16,16 +13,15 @@ function Authorization() {
   const [cookies] = useCookies(null);
 
   useEffect(() => {
-    // if (user != null) {
-    //   navigate("/profile");
-    // }
     const tryAutoLogin = async () => {
       try {
         const token = cookies.token
-        let request = await autoLogin({ token: token, refresh: "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjo0LCJleHAiOjE2ODc2Mjk4MDh9.XlwiPmLb5Euc21zvdBSotP-HTp83-wf1HNmV_l60_u" });
+        const refresh = cookies.refresh
+        let request = await autoLogin({ token: token, refresh: refresh }).unwrap();
         console.log(request);
         if (request.token && request.refresh) {
-          // this is fine
+          navigate("/profile")
+          console.log("auto login success")
         } else if (request.error) {
           navigate("/auth")
         }
@@ -33,13 +29,10 @@ function Authorization() {
       } catch (err) {
         console.error(err)
       }
-
     }
     tryAutoLogin();
 
   }, []);
-
-
 
   return (
     <div className="auth-login">

--- a/client/src/pages/auth/Authorization.jsx
+++ b/client/src/pages/auth/Authorization.jsx
@@ -21,8 +21,8 @@ function Authorization() {
         let request = await autoLogin({ token: token, refresh: refresh }).unwrap();
         if (request.token && request.refresh) {
           setCookie("token", request.token);
-          setCookie("refresh", request.refresh)
-          navigate("/profile")
+          setCookie("refresh", request.refresh);
+          navigate("/profile");
         } else if (request.error) {
           navigate("/auth")
         }

--- a/client/src/pages/auth/Authorization.jsx
+++ b/client/src/pages/auth/Authorization.jsx
@@ -10,18 +10,19 @@ function Authorization() {
   const navigate = useNavigate();
   const user = useSelector(selectCurrentUser);
   const [autoLogin] = useAutoLoginMutation();
-  const [cookies] = useCookies(null);
+  const [cookies, setCookie] = useCookies(null);
 
   useEffect(() => {
     const tryAutoLogin = async () => {
+
       try {
         const token = cookies.token
         const refresh = cookies.refresh
         let request = await autoLogin({ token: token, refresh: refresh }).unwrap();
-        console.log(request);
         if (request.token && request.refresh) {
+          setCookie("token", request.token);
+          setCookie("refresh", request.refresh)
           navigate("/profile")
-          console.log("auto login success")
         } else if (request.error) {
           navigate("/auth")
         }

--- a/client/src/pages/auth/Authorization.jsx
+++ b/client/src/pages/auth/Authorization.jsx
@@ -1,28 +1,42 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import Login from "./Login";
-// import Signup from "./Signup";
 import { selectCurrentUser } from "../../store/auth/userSlice";
 import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
+import { useCookies } from "react-cookie";
+import { useAutoLoginMutation } from "../../store/auth/authApiSlice";
 
 function Authorization() {
   const navigate = useNavigate();
-
   const user = useSelector(selectCurrentUser);
+  const [autoLogin] = useAutoLoginMutation();
+  const [cookies, setCookie] = useCookies(null);
 
   useEffect(() => {
-    if (user != null) {
-      navigate("/profile");
+    // if (user != null) {
+    //   navigate("/profile");
+    // }
+    const tryAutoLogin = async () => {
+      try {
+        const token = cookies.token
+        let request = await autoLogin({ token: token }).unwrap();
+        console.log(request)
+
+      } catch (err) {
+        console.error(err)
+      }
+
     }
+    tryAutoLogin();
+
   }, []);
+
+
 
   return (
     <div className="auth-login">
       <Login />
     </div>
-    /* <div className="auth-signup">
-        <Signup />
-      </div> */
   );
 }
 

--- a/client/src/pages/auth/Authorization.jsx
+++ b/client/src/pages/auth/Authorization.jsx
@@ -6,11 +6,14 @@ import { useNavigate } from "react-router-dom";
 import { useCookies } from "react-cookie";
 import { useAutoLoginMutation } from "../../store/auth/authApiSlice";
 
+const tempJWT = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjo0LCJleHAiOjE2ODc2Mjk4MDh9.XlwiPmLb5Euc21zvdBSotP-HTp83-wf1HNmV_l60_uU"
+
+
 function Authorization() {
   const navigate = useNavigate();
   const user = useSelector(selectCurrentUser);
   const [autoLogin] = useAutoLoginMutation();
-  const [cookies, setCookie] = useCookies(null);
+  const [cookies] = useCookies(null);
 
   useEffect(() => {
     // if (user != null) {
@@ -19,8 +22,13 @@ function Authorization() {
     const tryAutoLogin = async () => {
       try {
         const token = cookies.token
-        let request = await autoLogin({ token: token }).unwrap();
-        console.log(request)
+        let request = await autoLogin({ token: token, refresh: "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjo0LCJleHAiOjE2ODc2Mjk4MDh9.XlwiPmLb5Euc21zvdBSotP-HTp83-wf1HNmV_l60_u" });
+        console.log(request);
+        if (request.token && request.refresh) {
+          // this is fine
+        } else if (request.error) {
+          navigate("/auth")
+        }
 
       } catch (err) {
         console.error(err)

--- a/client/src/pages/auth/Login.jsx
+++ b/client/src/pages/auth/Login.jsx
@@ -35,8 +35,7 @@ function Login() {
       const userData = await login({ email, password }).unwrap();
       dispatch(setUserInfo({ ...userData }));
       setCookie("token", userData.token);
-      // localStorage.setItem("workouts", JSON.stringify(userData.workouts));
-      // localStorage.setItem("competitions", JSON.stringify(userData.competitions));
+      setCookie("refresh", userData.refresh)
       localStorage.setItem("user", JSON.stringify(userData.user));
       setEmail("");
       setPassword("");

--- a/client/src/pages/auth/RequireAuth.jsx
+++ b/client/src/pages/auth/RequireAuth.jsx
@@ -17,6 +17,9 @@ function RequireAuth() {
     try {
       const token = cookies.token
       const refresh = cookies.refresh
+      if (!token || !refresh) {
+        return;
+      }
       let request = await autoLogin({ token: token, refresh: refresh }).unwrap();
       // console.log(request);
       if (request.token && request.refresh) {

--- a/client/src/pages/auth/RequireAuth.jsx
+++ b/client/src/pages/auth/RequireAuth.jsx
@@ -18,9 +18,10 @@ function RequireAuth() {
       const token = cookies.token
       const refresh = cookies.refresh
       let request = await autoLogin({ token: token, refresh: refresh }).unwrap();
-      console.log(request);
+      // console.log(request);
       if (request.token && request.refresh) {
-        // console.log("auto login successful")
+        setCookie("token", request.token);
+        setCookie("refresh", request.refresh)
         // navigate('/profile')
       } else {
         navigate("/auth");

--- a/client/src/pages/auth/RequireAuth.jsx
+++ b/client/src/pages/auth/RequireAuth.jsx
@@ -1,23 +1,49 @@
-import { useLocation, Navigate, Outlet } from "react-router-dom";
+import { useLocation, useNavigate, Outlet } from "react-router-dom";
 import { useSelector } from "react-redux";
 import {
   selectCurrentToken,
   selectCurrentUser,
 } from "../../store/auth/userSlice";
 import Header from "../../components/Header";
+import { useCookies } from "react-cookie";
+import { useAutoLoginMutation } from "../../store/auth/authApiSlice";
+import { useEffect } from "react";
 
 function RequireAuth() {
-  const token = useSelector(selectCurrentToken);
+  // const token = useSelector(selectCurrentToken);
   const user = useSelector(selectCurrentUser);
   const location = useLocation();
-  return user ? (
-    <div>
-      <Header />
-      <Outlet />
-    </div>
-  ) : (
-    <Navigate to="/auth" replace />
-  );
+  const [autoLogin] = useAutoLoginMutation();
+  const [cookies, setCookie] = useCookies(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    tryAutoLogin();
+  }, [])
+
+  const tryAutoLogin = async () => {
+    try {
+      const token = cookies.token
+      const refresh = cookies.refresh
+      let request = await autoLogin({ token: token, refresh: refresh }).unwrap();
+      console.log(request);
+      if (request.token && request.refresh) {
+        console.log("auto login successful")
+        return (
+          <div>
+            <Header />
+            <Outlet />
+          </div>
+        )
+      } else {
+        navigate("/auth");
+      }
+
+    } catch (err) {
+      console.error(err)
+    }
+
+  }
 }
 
 export default RequireAuth;

--- a/client/src/pages/auth/RequireAuth.jsx
+++ b/client/src/pages/auth/RequireAuth.jsx
@@ -1,18 +1,10 @@
-import { useLocation, useNavigate, Outlet } from "react-router-dom";
-import { useSelector } from "react-redux";
-import {
-  selectCurrentToken,
-  selectCurrentUser,
-} from "../../store/auth/userSlice";
+import { useNavigate, Outlet } from "react-router-dom";
 import Header from "../../components/Header";
 import { useCookies } from "react-cookie";
 import { useAutoLoginMutation } from "../../store/auth/authApiSlice";
 import { useEffect } from "react";
 
 function RequireAuth() {
-  // const token = useSelector(selectCurrentToken);
-  const user = useSelector(selectCurrentUser);
-  const location = useLocation();
   const [autoLogin] = useAutoLoginMutation();
   const [cookies, setCookie] = useCookies(null);
   const navigate = useNavigate();
@@ -28,13 +20,8 @@ function RequireAuth() {
       let request = await autoLogin({ token: token, refresh: refresh }).unwrap();
       console.log(request);
       if (request.token && request.refresh) {
-        console.log("auto login successful")
-        return (
-          <div>
-            <Header />
-            <Outlet />
-          </div>
-        )
+        // console.log("auto login successful")
+        // navigate('/profile')
       } else {
         navigate("/auth");
       }
@@ -44,6 +31,12 @@ function RequireAuth() {
     }
 
   }
+  return (
+    <div>
+      <Header />
+      <Outlet />
+    </div>
+  )
 }
 
 export default RequireAuth;

--- a/client/src/store/auth/authApiSlice.js
+++ b/client/src/store/auth/authApiSlice.js
@@ -29,8 +29,21 @@ export const authApiSlice = apiSlice.injectEndpoints({
         method: "PATCH",
         body: { ...credentials },
       })
+    }),
+    autoLogin: builder.mutation({
+      query: (credentials) => ({
+        url: "auth/autologin",
+        method: "POST",
+        body: { ...credentials },
+      }),
     })
   }),
 });
 
-export const { useLoginMutation, useSignupMutation, useLogoutMutation, useUpdateProfileMutation } = authApiSlice;
+export const {
+  useLoginMutation,
+  useSignupMutation,
+  useLogoutMutation,
+  useUpdateProfileMutation,
+  useAutoLoginMutation,
+} = authApiSlice;

--- a/client/src/store/auth/userSlice.js
+++ b/client/src/store/auth/userSlice.js
@@ -4,11 +4,11 @@ const userSlice = createSlice({
   name: "user",
   initialState: {
     user: JSON.parse(localStorage.getItem("user")) || null,
-    token: document.cookie.slice(6) || null,
+    token: document.cookie.split(" ")[0].slice(6, -1) || null,
+    refresh: document.cookie.split(" ")[1].slice(7, -1) || null,
   },
   reducers: {
     setUserInfo: (state, action) => {
-      // console.log("set user info run")
       Object.keys(action.payload).forEach(key => {
         state[key] = action.payload[key];
       });

--- a/client/src/store/auth/userSlice.js
+++ b/client/src/store/auth/userSlice.js
@@ -3,7 +3,7 @@ import { createSlice } from "@reduxjs/toolkit";
 const getJWTCookie = (key) => {
   const cookies = document.cookie.split(" ");
   const token = cookies.find(string => string.startsWith(key));
-  return token.replace(`${key}=`, "");
+  return token?.replace(`${key}=`, "").replace(";", "");
 };
 
 const userSlice = createSlice({

--- a/client/src/store/auth/userSlice.js
+++ b/client/src/store/auth/userSlice.js
@@ -1,11 +1,17 @@
 import { createSlice } from "@reduxjs/toolkit";
 
+const getJWTCookie = (key) => {
+  const cookies = document.cookie.split(" ");
+  const token = cookies.find(string => string.startsWith(key));
+  return token.replace(`${key}=`, "");
+};
+
 const userSlice = createSlice({
   name: "user",
   initialState: {
     user: JSON.parse(localStorage.getItem("user")) || null,
-    token: document.cookie.split(" ")[0].slice(6, -1) || null,
-    refresh: document.cookie.split(" ")[1].slice(7, -1) || null,
+    token: getJWTCookie("token") || null,
+    refresh: getJWTCookie("refresh") || null,
   },
   reducers: {
     setUserInfo: (state, action) => {


### PR DESCRIPTION
This PR starts to address Issue #146 

* authentication_controller - added refresh token with 90 day expiry on login and signup. Blacklists refresh token on logout. 
* Add autologin route - which tries to authenticate request with token. If that fails, it will try to authenticate with refresh token. If that is successful, return new tokens. If that fails, then return authorized
* JsonWebToken - added jwt_refresh method that generates a refresh token with 90 day expiry

Auth Routes on Client
* Add 404 page not found for any routes that are not defined
* Add tryAutoLogin functions to Authorization and RequireAuth components, which redirects to "/profile" if successful, otherwise redirects to "/auth"
* Created useAutoLoginMutation endpoint

WIP 
* still need to test background task of deleting expired blacklisted tokens
* still need to test that JWT is refreshed if token is expired by refresh token is still valid