### PR TITLE
144 searchable input

### DIFF
--- a/client/src/pages/tournaments/CompetitionPage.css
+++ b/client/src/pages/tournaments/CompetitionPage.css
@@ -90,7 +90,9 @@ form.record-workout-form label {
     width: 170px;
 }
 
-
+form.record-workout-form datalist option {
+    display:none;
+}
 input.add-workout-submit {
     height: 30px;
     background-color: beige;

--- a/client/src/pages/tournaments/Record.jsx
+++ b/client/src/pages/tournaments/Record.jsx
@@ -67,6 +67,9 @@ function Record({ comp }) {
   });
   const [addWorkout, { isLoading }] = useAddWorkoutMutation();
 
+  const [search, setSearch] = useState('')
+  const filteredActivities = activities.filter(activity => activity.toLowerCase().includes(search.toLowerCase()))
+  
   const handleInput = (e) => {
     if (e.target.name === "duration") {
       setWorkoutData({ ...workoutData, duration: parseInt(e.target.value) });
@@ -109,18 +112,23 @@ function Record({ comp }) {
       <div>
         <h2>Record Workout</h2>
         <form onSubmit={createWorkout} className="record-workout-form">
-          <select
-            onChange={handleInput}
-            name="activity"
-            defaultValue="activity"
+          <input
+            type="text"
+            id="combobox"
+            placeholder="Type a name to search..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            list="options"
+            autoComplete="off"
+          />
+          <datalist
+            id="options"
           >
-            <option value="activity" disabled hidden>
-              Select Activity
-            </option>
             {activities.sort().map((activity) => {
-              return <option key={activity}>{activity}</option>;
+              return <option key={activity} value={activity}></option>;
             })}
-          </select>
+          </datalist>
+
           <label htmlFor="duration">Duration (mins):</label>
           <input
             type="number"

--- a/client/src/pages/tournaments/Record.jsx
+++ b/client/src/pages/tournaments/Record.jsx
@@ -67,9 +67,6 @@ function Record({ comp }) {
   });
   const [addWorkout, { isLoading }] = useAddWorkoutMutation();
 
-  const [search, setSearch] = useState('')
-  const filteredActivities = activities.filter(activity => activity.toLowerCase().includes(search.toLowerCase()))
-  
   const handleInput = (e) => {
     if (e.target.name === "duration") {
       setWorkoutData({ ...workoutData, duration: parseInt(e.target.value) });
@@ -116,8 +113,6 @@ function Record({ comp }) {
             type="text"
             id="combobox"
             placeholder="Type a name to search..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
             list="options"
             autoComplete="off"
           />


### PR DESCRIPTION
This PR addresses issue #144 

**client/src/pages/tournaments/Record.jsx**:

- Since the desired functionality isn't supported by the select tag, I replaced it with an input field. The list attribute points to the following dataset tag, which contains all of the activities. When the user types an activity, it filters out the activities that don't match the input (which occurs inside of the dataset tag).

**client/src/pages/tournaments/CompetitionPage.css**:

- Implimented styling to hide empty options tags from the DOM. These options tags were caused by the new datalist tag and were distorting the styling for the new workout form. 