### PR TITLE
build simple pagination of posts

### DIFF
--- a/client/src/pages/tournaments/PostPageNums.css
+++ b/client/src/pages/tournaments/PostPageNums.css
@@ -1,0 +1,17 @@
+ol.post-page-number-list {
+    display: flex;
+    justify-content: center;
+    margin-top: 0.5em;
+}
+
+li.post-page-number {
+    list-style: none;
+    padding: 0 0.5em;
+    font-size: large;
+}
+
+li.post-page-number:hover {
+    color: green;
+    text-decoration-line: underline;
+    cursor: pointer;
+}

--- a/client/src/pages/tournaments/PostPageNums.jsx
+++ b/client/src/pages/tournaments/PostPageNums.jsx
@@ -1,0 +1,29 @@
+import "./PostPageNums.css";
+
+const PostPageNums = ({ numOfPages, pageNum, setPageNum }) => {
+    const pageArray = [];
+    for (let i = 0; i < numOfPages; i++) {
+        pageArray.push(i + 1);
+    };
+    const pageNums = pageArray.map((page, i) => {
+        return (
+            <li
+                className="post-page-number"
+                key={`page-number-${i + 1}`}
+                onClick={() => setPageNum(page - 1)}
+                style={pageNum === page - 1 ? { fontWeight: "bold" } : null}
+            >{page}
+            </li>
+        );
+    });
+
+    return (
+        <>
+            <ol className="post-page-number-list"
+            >Page {pageNums}
+            </ol>
+        </>
+    );
+};
+
+export default PostPageNums;

--- a/client/src/pages/tournaments/Posts.jsx
+++ b/client/src/pages/tournaments/Posts.jsx
@@ -1,10 +1,12 @@
 import PostCard from "./PostCard";
 import CreateIcon from '@mui/icons-material/Create';
 import InputOption from '../account/InputOption';
+import PostPageNums from "./PostPageNums";
 import ImageIcon from '@mui/icons-material/Image';
 import SubscriptionsIcon from '@mui/icons-material/Subscriptions';
 import EventNoteIcon from '@mui/icons-material/EventNote';
 import InsertCommentIcon from '@mui/icons-material/InsertComment';
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import * as yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
@@ -17,13 +19,11 @@ import { useGetPostsQuery } from "../../store/game/feedApiSlice";
 
 function Posts({ posts, comp }) {
   const { refetch } = useGetPostsQuery(comp.id);
-  const renderedPosts = posts?.map((post) => {
-    return <PostCard key={post.id} post={post} />;
-  });
-
   const dispatch = useDispatch();
   const user = useSelector(selectCurrentUser);
   const [addPost, { isLoading }] = useAddPostMutation();
+  const NUM_OF_POSTS_PER_PAGE = 5;
+  const [pageNum, setPageNum] = useState(0);
 
   const schema = yup.object().shape({
     description: yup.string().required(),
@@ -46,6 +46,12 @@ function Posts({ posts, comp }) {
     dispatch(setPosts([...posts, newPost]));
     setValue("description", "");
   };
+
+  const renderedPosts = posts?.slice(pageNum * NUM_OF_POSTS_PER_PAGE, (pageNum + 1) * NUM_OF_POSTS_PER_PAGE).map((post) => {
+    return <PostCard key={post.id} post={post} />;
+  });
+
+  const numOfPages = Math.ceil(posts?.length / NUM_OF_POSTS_PER_PAGE);
 
   return (
     <div className="posts">
@@ -80,6 +86,7 @@ function Posts({ posts, comp }) {
         </div> */}
       </div>
       {renderedPosts}
+      {posts.length > 0 && <PostPageNums numOfPages={numOfPages} pageNum={pageNum} setPageNum={setPageNum} />}
     </div>
   );
 }


### PR DESCRIPTION
This addresses Issue #164 

Simple pagination of Posts in Tournament Page:
* All posts are fetched 
* Client will render first [5] posts
* Page numbers at the bottom which render each successful [5] posts
* Number of posts per page can be easily configured by changing constant NUM_OF_POSTS_PER_PAGE
* Basic styling