### PR TITLE
add redis and sidekiq to clean up expired jwt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ api/config/master.key
 api/.DS_Store
 api/.byebug_history
 
+api/db/dump.rdb
+
 
 ####### client #######
 # dependencies

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -55,3 +55,6 @@ gem "active_model_serializers", "~> 0.10.13"
 gem 'byebug', '~> 11.1', '>= 11.1.3'
 
 gem 'whenever', require: false
+
+gem "sidekiq", "~> 7.1"
+gem 'sidekiq-cron'

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -80,12 +80,18 @@ GEM
       activesupport
     chronic (0.10.2)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
     crass (1.0.6)
     date (3.3.3)
     debug (1.7.1)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     erubi (1.12.0)
+    et-orbi (1.2.7)
+      tzinfo
+    fugit (1.8.1)
+      et-orbi (~> 1, >= 1.2.7)
+      raabro (~> 1.4)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -129,6 +135,7 @@ GEM
     pg (1.4.6)
     puma (5.6.5)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.6.2)
     rack (2.2.6.3)
     rack-cors (2.0.1)
@@ -162,8 +169,19 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
+    redis-client (0.14.1)
+      connection_pool
     reline (0.3.2)
       io-console (~> 0.5)
+    sidekiq (7.1.1)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.14.0)
+    sidekiq-cron (1.10.1)
+      fugit (~> 1.8)
+      globalid (>= 1.0.1)
+      sidekiq (>= 6)
     thor (1.2.1)
     timeout (0.3.2)
     tzinfo (2.0.6)
@@ -191,6 +209,8 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-cors
   rails (~> 7.0.4, >= 7.0.4.2)
+  sidekiq (~> 7.1)
+  sidekiq-cron
   tzinfo-data
   whenever
 

--- a/api/app/workers/cleanup_expired_jwt_job.rb
+++ b/api/app/workers/cleanup_expired_jwt_job.rb
@@ -1,0 +1,9 @@
+class CleanupExpiredJwtJob
+  include Sidekiq::Worker
+
+  def perform(*args)
+    puts "Running cleanup_expired_jwt"
+    BlacklistedToken.where("expires_at < ? ", Time.current).delete_all
+    puts "Delete expired tokens"
+  end
+end

--- a/api/config/initializers/sidekiq_cron.rb
+++ b/api/config/initializers/sidekiq_cron.rb
@@ -1,0 +1,6 @@
+Sidekiq::Cron::Job.create(
+    name: 'Clean up expired tokens daily',
+    cron: '0 3 * * *', # Run at 3:00AM UTC daily
+    # cron: '*/1 * * * *', # Run every 1 minute
+    class: 'CleanupExpiredJwtJob'
+)

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,7 +1,10 @@
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
 
   #action cable server
   mount ActionCable.server => "/cable"
+  mount Sidekiq::Web => '/sidekiq'
 
   resources :messages
   resources :likes, only: [:create, :destroy]

--- a/api/config/sidekiq.yml
+++ b/api/config/sidekiq.yml
@@ -1,0 +1,11 @@
+
+:concurrency: 10
+:pidfile: ./tmp/pids/sidekiq.pid
+:logfile: ./log/sidekiq.log
+:queues:
+  - default
+
+:redis:
+  :url: redis://redis:6379
+  :driver: redis
+  :dir: ./api/db/redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 services:
+
   db:
     image: postgres
     volumes:
@@ -6,6 +7,18 @@ services:
     environment:
       POSTGRES_PASSWORD: password
     working_dir: /api
+
+  redis:
+    image: 'redis:7-alpine'
+    command: redis-server
+    ports:
+      - '6379:6379'
+
+  helper:
+    image: alpine
+    command: sh -c "echo never > /sys/kernel/mm/transparent_hugepage/enabled"
+    privileged: true
+
   api:
     image: rails-api-backend
     build: api
@@ -19,6 +32,12 @@ services:
     working_dir: /api
     depends_on:
       - db
+      - sidekiq
+      - redis
+    environment:
+      - RAILS_ENV=development
+      - REDIS_URL=redis://redis:6379/
+
   client:
     build: client
     image: react-client-frontend
@@ -30,3 +49,13 @@ services:
       - ./client:/client
     environment:
       POSTGRES_PASSWORD: password
+
+  sidekiq:
+    build: api
+    command: bundle exec sidekiq -C config/sidekiq.yml
+    volumes:
+      - './api:/api'
+      - '/api/tmp'
+      - './api/db:/api/db'
+    environment:
+      REDIS_URL: redis://redis:6379


### PR DESCRIPTION
This addresses Issue #149 

1. Add gems: sidekiq and sidekiq-cron;
2. Create sidekiq_cron.rb that specifies when and what task shall be run;
3. Create cleanup_expired_jwt_job.rb that provies the function for deleting blacklisted expired JWT;
4. Update docker-compose.yaml  to add redis and sidekiq services

To test;
1. Uncomment Line 4 of cleanup_expired_jwt.rb and comment out Line 3.  (This changes the timing of the background task to run every minute rather than every day. This is just for testing purposes. After test. Reverse this step).

2. Rebuild application given changes to gemfile and docker compose file;
```
docker-compose up --build
```
3. Console should show 5 services: db, api, client, redis and sidekiq;
4. In a new terminal, run
```
docker compose run api rails console
BlacklistedToken.all
```
This should show a list of all blacklisted tokens. 
5. Navigate to localhost:4000. Login as any user and then logout (to create the blacklisted token).
6. In the rails console, run BlacklistedToken.all again. You should see 2 new instances that were created by logging out in step 4.
7. Wait ~ 1 minute then check the docker terminal. You should see something like this: 

![Screen Shot 2023-06-06 at 5 42 48 PM](https://github.com/Fantasy-Fit/fantasy-fit-web/assets/111921809/3a02b6e5-0b74-4b26-802b-81a5e3ccbf7d)

8. In the rails console, run BlacklistedToken.all again. You should see the two instances have been deleted:

![Screen Shot 2023-06-06 at 5 44 48 PM](https://github.com/Fantasy-Fit/fantasy-fit-web/assets/111921809/1c0c3b7a-844c-464d-9602-92ad1fe2b176)

9. After testing is complete. Reverse step 1 by commenting out Line 4 of cleanup_expired_jwt.rb and uncomment Line 3. 

Note: have only tested this in localhost and dev environment. Will test in production next.