### PR TITLE
refactored dockerfiles to reduce image sizes

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,11 @@
-FROM ruby:2.7.4
-RUN apt-get update -qq && apt-get install -y nodejs postgresql-client
+FROM ruby:3.2.2-slim-bullseye
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential curl git libpq-dev \
+    && apt-get update && apt-get install -y --no-install-recommends nodejs yarn \
+    && rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man \
+    && apt-get clean
+
 WORKDIR /api
 COPY . .
 COPY Gemfile /api/Gemfile

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "2.7.4"
+ruby "3.2.2"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.4", ">= 7.0.4.2"

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,16 +1,18 @@
-FROM node
+FROM node:18-alpine AS build
+
+# STAGE 1 - copy app, install dependencies and build
+WORKDIR /client
+COPY package.json .
+RUN yarn install
+COPY . /client
+RUN npm run build
+
+# STAGE 2
+FROM node:18-alpine
 
 WORKDIR /client
-# # Copy app files
-COPY package.json .
-
-# add `/app/node_modules/.bin` to $PATH
-# ENV PATH /client/node_modules/.bin:$PATH
-
-# install app dependencies
-COPY package.json ./client/package.json
-COPY package-lock.json ./client/package-lock.json
-RUN npm install
+RUN npm install -g webserver.local
+COPY --from=build /client/dist ./build
 
 # add app
 COPY . ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 services:
+
   db:
     image: postgres
     volumes:
@@ -6,6 +7,18 @@ services:
     environment:
       POSTGRES_PASSWORD: password
     working_dir: /api
+
+  redis:
+    image: 'redis:7-alpine'
+    command: redis-server
+    ports:
+      - '6379:6379'
+
+  helper:
+    image: alpine
+    command: sh -c "echo never > /sys/kernel/mm/transparent_hugepage/enabled"
+    privileged: true
+
   api:
     image: rails-api-backend
     build: api
@@ -19,6 +32,8 @@ services:
     working_dir: /api
     depends_on:
       - db
+      - redis
+
   client:
     build: client
     image: react-client-frontend


### PR DESCRIPTION
1. Update Ruby to 3.2.2;
2. Add redis and helper services to docker-compose;
3. Refactored dockerfile for client  - use node:18-alpine and multi stage build to reduce image size
4. Refactored dockerfile for api - use ruby:3.2.2-slim-bullseye and update dependencies to reduce image size

Time to build ~ 122s
Image sizes: client reduced from 1.27GB to 309MB. rails api reduced from 1.07GB to 678MB

![Screen Shot 2023-06-06 at 11 39 22 PM](https://github.com/Fantasy-Fit/fantasy-fit-web/assets/111921809/6212dc2d-0148-4348-8de3-40b6a8be14d1)

This addresses issue #172 
